### PR TITLE
Better handling of environment installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,28 +16,38 @@ For any question or suggestion, you can write an email to [support@homebox.space
 ## Provisioning
 
 This folder contains some of the code to control the testing environment on Vultr, and will be completed as an ongoing
-process. The servers are controlled through Jenkins on https://henkins.homebox.space, but this can also be done from the
+process. The servers are controlled through Jenkins on https://jenkins.homebox.space, but this can also be done from the
 command line, with an API key, like the examples below.
 
 This is a huge “work-in-progress”, but it is enough for now to drive the tests of two flavours of homebox
-instances. There is no dynamic inventories yet, and the IP addresses are hardcoded in the Jenkins jobs.
-Using dynamic inventories will require creating or updating the DNS GLUE records and the DNSSEC keys (ZSK and KSK) on
-the DNS provider as well.
+instances. The playbooks is called by Jenkins, to run the continuous integration tests.
+
+For the tests to run correctly, a docker-compose is used that provides a staging Acme server, a DNS server and a package
+proxy cache. There is a repository to build the Jenkins continuous integration stack with a specific domain, hosted on
+[GitHub](https://github.com/progmaticltd/homebox-jenkins).
+
+This local repository does the following:
+
+1. Start (optionally after reinstall) the virtual machine(s) needed for the tests
+2. Activate the private IP address of the virtual machine
+3. Attach the private IP address to the docker network of the continuous integration server
+
+The Jenkins CI server is responsible of starting the installation and the integration tests.
 
 ### To start the environment
 
-This will create the servers if they don't exists.
+The following command example will create the _Buster_ servers if they don't exists, and start them:
 
 ```sh
 export VULTR_API_KEY='RAR56637DKULV27RML4ACCFFKQSR2TOV6FR8'
-ansible-playbook -i config/hosts.yml -vv vultr/playbooks/environment-start.yml
+ansible-playbook -vv -i ../config/hosts-local.yml -e env=vultr -e testing=buster playbooks/environment-start.yml
 ```
 
 ### To stop the environment
 
 ```sh
 export VULTR_API_KEY='RAR56637DKULV27RML4ACCFFKQSR2TOV6FR8'
-ansible-playbook -i config/hosts.yml -vv vultr/playbooks/environment-stop.yml
+ansible-playbook -vv -i ../config/hosts-local.yml -e env=vultr -e testing=buster playbooks/environment-stop.yml
 ```
 
 The servers are automatically turned off after the tests.
@@ -48,5 +58,11 @@ This will be used for the weekly tests, when the stack is installed from scratch
 
 ```sh
 export VULTR_API_KEY='RAR56637DKULV27RML4ACCFFKQSR2TOV6FR8'
-ansible-playbook -i config/hosts.yml -vv vultr/playbooks/environment-reinstall.yml
+ansible-playbook -vv -i ../config/hosts-local.yml -e env=vultr -e testing=buster playbooks/environment-reisntall.yml
 ```
+
+**Note:**
+
+The repository is organised in a way that makes possible to create new cloud providers easily. Copy the _vultr_ folder,
+with another provider name, create the code to start, stop and reinstall the virtual machines, and _voila_. The only
+requirement is the virtual machines should able to reach the docker IP address of the continuous integration server.

--- a/provisioning/config/systems-vultr.yml
+++ b/provisioning/config/systems-vultr.yml
@@ -16,9 +16,11 @@ vultr:
       hostname: main
       firewall_group: 'homebox-server'
       private_network_enabled: true
+      testing: [ 'stretch' ]
     - name: buster-nano
       os: Debian 10 x64 (buster)
       ipv6_enabled: false
       hostname: main
       firewall_group: 'homebox-server'
       private_network_enabled: true
+      testing: [ 'buster' ]

--- a/provisioning/vultr/roles/setup-environment/defaults/main.yml
+++ b/provisioning/vultr/roles/setup-environment/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+reinstall:
+  # Wait 5 minutes maximum for a server to be re-installed
+  timeout: 300

--- a/provisioning/vultr/roles/setup-environment/tasks/main.yml
+++ b/provisioning/vultr/roles/setup-environment/tasks/main.yml
@@ -3,6 +3,6 @@
 - name: Set up all the server instances
   include_tasks: setup-one.yml
   with_items:
-    - '{{ vultr.instances }}'
+    - '{{ vultr.instances | selectattr("testing", "contains", testing) | list }}'
   loop_control:
     loop_var: instance

--- a/provisioning/vultr/roles/setup-environment/tasks/setup-one.yml
+++ b/provisioning/vultr/roles/setup-environment/tasks/setup-one.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: 'Set the server instance state'
+- name: Set the server instance state
   delegate_to: localhost
   register: api_answer
   vultr_server:
@@ -13,6 +13,14 @@
     ipv6_enabled: '{{ instance.ipv6_enabled }}'
     hostname: '{{ instance.hostname }}'
     firewall_group: '{{ instance.firewall_group }}'
+
+- name: Wait for the machine to be reinstalled
+  when: state == 'reinstalled'
+  delegate_to: localhost
+  wait_for_connection:
+    delay: 30
+    sleep: 10
+    timeout: '{{ reinstall.timeout }}'
 
 - name: Store the private IP address
   when: state != 'stopped'


### PR DESCRIPTION
- Add a timeout after the re-install to wait for the connection to be
  available
- Updated documentation
- Allow to filter wich virtual machines to start, by OS.