### PR TITLE
Remove obsolete check-api-access from vultr provisioning

### DIFF
--- a/provisioning/vultr/playbooks/environment-check.yml
+++ b/provisioning/vultr/playbooks/environment-check.yml
@@ -1,14 +1,5 @@
 ---
 
-- name: Check API access
-  hosts: localhost
-  connection: local
-  become: false
-  vars_files:
-    - '{{ playbook_dir }}/../../config/systems-{{ env }}.yml'
-  roles:
-    - check-api-access
-
 - name: Create and start the test instances
   hosts: localhost
   connection: local

--- a/provisioning/vultr/playbooks/environment-reinstall.yml
+++ b/provisioning/vultr/playbooks/environment-reinstall.yml
@@ -1,14 +1,5 @@
 ---
 
-- name: Check API access
-  hosts: localhost
-  connection: local
-  become: false
-  vars_files:
-    - '{{ playbook_dir }}/../../config/systems-{{ env }}.yml'
-  roles:
-    - check-api-access
-
 - name: Reinstall and start all the test instances
   hosts: localhost
   connection: local

--- a/provisioning/vultr/playbooks/environment-start.yml
+++ b/provisioning/vultr/playbooks/environment-start.yml
@@ -1,14 +1,5 @@
 ---
 
-- name: Check API access
-  hosts: localhost
-  connection: local
-  become: false
-  vars_files:
-    - '{{ playbook_dir }}/../../config/systems-{{ env }}.yml'
-  roles:
-    - check-api-access
-
 - name: Create and start the test instances
   hosts: localhost
   connection: local

--- a/provisioning/vultr/playbooks/environment-stop.yml
+++ b/provisioning/vultr/playbooks/environment-stop.yml
@@ -1,14 +1,5 @@
 ---
 
-- name: Check API access
-  hosts: localhost
-  connection: local
-  become: false
-  vars_files:
-    - '{{ playbook_dir }}/../../config/systems-{{ env }}.yml'
-  roles:
-    - check-api-access
-
 - name: Stop all the test instances
   hosts: localhost
   connection: local

--- a/provisioning/vultr/roles/check-api-access/tasks/main.yml
+++ b/provisioning/vultr/roles/check-api-access/tasks/main.yml
@@ -1,5 +1,0 @@
----
-
-- name: Get the plan facts
-  local_action:
-    module: vultr_plan_facts


### PR DESCRIPTION
A small one, nothing major, just to keep you updated.